### PR TITLE
Avoid attribute error on flake8-import-order 0.16 version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     maintainer_email='dev' '@' 'spoqa.com',
     license='GPLv3 or later',
     py_modules=['flake8_import_order_spoqa'],
-    install_requires=['flake8-import-order >= 0.14.2'],
+    install_requires=['flake8-import-order >= 0.14.2, < 0.16'],
     entry_points='''
         [flake8_import_order.styles]
         spoqa = flake8_import_order_spoqa:Spoqa


### PR DESCRIPTION
https://ci.appveyor.com/project/Spoqa95755/dodo-point-assist/build/1.0.595

flake8-import-order 0.16 버전이 설치되면 발생하는 `AttributeError` 를 회피하기위해 임시조치로 버전을 고정