### PR TITLE
Avoid import error on flake8-import-order 0.17 version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     maintainer_email='dev' '@' 'spoqa.com',
     license='GPLv3 or later',
     py_modules=['flake8_import_order_spoqa'],
-    install_requires=['flake8-import-order >= 0.14.2'],
+    install_requires=['flake8-import-order >= 0.14.2, 0.17'],
     entry_points='''
         [flake8_import_order.styles]
         spoqa = flake8_import_order_spoqa:Spoqa

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ setup(
     maintainer_email='dev' '@' 'spoqa.com',
     license='GPLv3 or later',
     py_modules=['flake8_import_order_spoqa'],
-    install_requires=['flake8-import-order <= 0.16'],
+    # Avoid import error on flake8-import-order 0.17 version
+    install_requires=['flake8-import-order == 0.16'],
     entry_points='''
         [flake8_import_order.styles]
         spoqa = flake8_import_order_spoqa:Spoqa


### PR DESCRIPTION
```c:\python27\lib\site-packages\flake8_import_order_spoqa.py:5: in <module>
    from flake8_import_order import (IMPORT_3RD_PARTY, IMPORT_APP,
E   ImportError: cannot import name IMPORT_3RD_PARTY```
