### PR TITLE
Update version of flake8-import-order to 0.18

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,6 +94,12 @@ Version 1.4.1
 
 To be released.
 
+- Python 3.7 can be supported by updating flake8-import-order to 0.18.
+  See its changelog__ to know more about
+  updates.
+
+__ https://github.com/PyCQA/flake8-import-order/blob/master/CHANGELOG.rst#018-2018-07-08
+
 
 Version 1.4.0
 ~~~~~~~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     license='GPLv3 or later',
     py_modules=['flake8_import_order_spoqa'],
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
-    install_requires=['flake8-import-order >= 0.17, < 0.18'],
+    install_requires=['flake8-import-order >= 0.18, < 0.19'],
     entry_points='''
         [flake8_import_order.styles]
         spoqa = flake8_import_order_spoqa:Spoqa


### PR DESCRIPTION
[flake8-import-order 0.18](https://github.com/PyCQA/flake8-import-order/blob/master/CHANGELOG.rst#018-2018-07-08) was released on July 8th. Since it supports Python 3.7, I think it is good to update the version. 
